### PR TITLE
Fix timezone date issue for display in transactions table

### DIFF
--- a/src/components/TransactionsTable.tsx
+++ b/src/components/TransactionsTable.tsx
@@ -10,6 +10,18 @@ const hoverDateFormat: { [id: string]: string } = {
     year: "numeric",
     month: "short",
     day: "numeric",
+    hour: "numeric",
+    timeZoneName: "short",
+    timeZone: "UTC",
+};
+
+const fixDate = (date: Date) => {
+    // display date relative to UTC
+    const hoursOff = date.getTimezoneOffset() / 60;
+    // console.log(date, date.getHours(), "hoursOff", hoursOff);
+    const newDate = new Date(date.setHours(date.getHours() + hoursOff));
+    // console.log("newDate", newDate);
+    return newDate;
 };
 
 const columns: ColumnDef<Transaction>[] = [
@@ -20,7 +32,7 @@ const columns: ColumnDef<Transaction>[] = [
         cell: (props) => (
             // temporary basic tooltip
             <div>
-                <span title={(props.getValue() as Date).toLocaleDateString(undefined, hoverDateFormat)}>{formatRelativeDate(props.getValue() as Date)}</span>
+                <span title={(props.getValue() as Date).toLocaleDateString(undefined, hoverDateFormat)}>{formatRelativeDate(fixDate(props.getValue() as Date))}</span>
             </div>
         ),
     },

--- a/src/components/TransactionsTable.tsx
+++ b/src/components/TransactionsTable.tsx
@@ -16,9 +16,7 @@ const hoverDateFormat: { [id: string]: string } = {
 const fixDate = (date: Date) => {
     // display date relative to UTC
     const hoursOff = date.getTimezoneOffset() / 60;
-    // console.log(date, date.getHours(), "hoursOff", hoursOff);
     const newDate = new Date(date.setHours(date.getHours() + hoursOff));
-    // console.log("newDate", newDate);
     return newDate;
 };
 

--- a/src/components/TransactionsTable.tsx
+++ b/src/components/TransactionsTable.tsx
@@ -10,8 +10,6 @@ const hoverDateFormat: { [id: string]: string } = {
     year: "numeric",
     month: "short",
     day: "numeric",
-    hour: "numeric",
-    timeZoneName: "short",
     timeZone: "UTC",
 };
 

--- a/src/utils/SheetsClient.ts
+++ b/src/utils/SheetsClient.ts
@@ -152,16 +152,16 @@ export default class SheetsClient {
 
         //convert dates to date objects
         const transactions = res.map((entry: any) => {
-            // TODO parse the date into a proper date object?
-            //Date usually has the form "Date(year,month,date)" (if the user didn't change anything)
+            // Sheets date usually has the form `Date(year,month,date)` (if the user didn't change anything)
             let [year, monthIndex, day] = entry["DATE"].substring(5, entry["DATE"].length - 1).split(",");
             monthIndex = parseInt(monthIndex);
             const month = monthIndex + 1;
-            let date = new Date(year, monthIndex, day);
-            let dateLocal = date.toLocaleDateString();
+            // let date = new Date(year, monthIndex, day); // uses local server timezone
+            let dateFromUTC = new Date(Date.UTC(year, monthIndex, day)); // uses UTC timezone
+            // console.log(entry["DATE"], "toString", dateFromUTC.toString(), "ISO", dateFromUTC.toISOString(), "UTC", dateFromUTC.toUTCString());
 
             return {
-                date: date, // `${year}-${month < 10 ? "0" + month : month}-${day < 10 ? "0" + day : day}`,
+                date: dateFromUTC,
                 merchant_company: entry["MERCHANT/COMPANY"],
                 amount: entry["AMOUNT"] || 0,
                 description: entry["DESCRIPTION"],
@@ -171,10 +171,7 @@ export default class SheetsClient {
                 reimbursed: entry["REIMBURSED"],
             };
         });
-        return transactions.map((transaction) => ({
-            ...transaction,
-            date: new Date(transaction.date), // TODO: ensure proper timezone
-        }));
+        return transactions;
     }
 
     // Categories


### PR DESCRIPTION
This PR formats all dates pulled from Sheets to UTC, and then displays them as UTC as well. This means regardless of what timezone you are in, the dates will match with Sheets.